### PR TITLE
Add ability to use YaraScanner in a multithreaded environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
     </licenses>
 
     <properties>
-        <hawtjni-version>1.11</hawtjni-version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <hawtjni-version>1.14</hawtjni-version>
         <hawtjni-verbose>true</hawtjni-verbose>
         <easymock-version>3.2</easymock-version>
         <jni-with-crypto>-lcrypto</jni-with-crypto>
@@ -27,19 +28,19 @@
         <dependency>
             <groupId>org.fusesource.hawtjni</groupId>
             <artifactId>hawtjni-runtime</artifactId>
-            <version>1.11</version>
+            <version>${hawtjni-version}</version>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.7</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
+            <version>1.2.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.6.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -74,7 +75,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <groupId>org.fusesource.hawtjni</groupId>
@@ -110,7 +111,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <dirset dir="${project.build.directory}/generated-sources/hawtjni/lib/META-INF/native/" id="platform">
                                     <include name="*" />
                                 </dirset>
@@ -118,11 +119,11 @@
                                       tofile="${project.build.directory}/generated-sources/hawtjni/lib/META-INF/native/${toString:platform}/yara"/>
                                 <copy file="${project.basedir}/../yarac"
                                       tofile="${project.build.directory}/generated-sources/hawtjni/lib/META-INF/native/${toString:platform}/yarac"/>
-                                <jar destfile="${project.build.directory}/${artifactId}-${version}-${toString:platform}.jar"
+                                <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}-${toString:platform}.jar"
                                         basedir="${project.build.directory}/generated-sources/hawtjni/lib/"
                                         update="true">
                                 </jar>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                     <execution>
@@ -132,7 +133,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <dirset dir="${project.build.directory}/generated-sources/hawtjni/lib/META-INF/native/" id="platform">
                                     <include name="*" />
                                 </dirset>
@@ -140,7 +141,7 @@
                                       tofile="${project.build.directory}/test-classes/META-INF/native/${toString:platform}/yara"/>
                                 <copy file="${project.basedir}/../yarac"
                                       tofile="${project.build.directory}/test-classes/META-INF/native/${toString:platform}/yarac"/>
-                            </tasks>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>
@@ -148,7 +149,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.3</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/java/com/github/plusvic/yara/Yara.java
+++ b/src/main/java/com/github/plusvic/yara/Yara.java
@@ -5,4 +5,6 @@ package com.github.plusvic.yara;
  */
 public interface Yara extends AutoCloseable {
     YaraCompiler createCompiler();
+  
+    void finalizeThread();
 }

--- a/src/main/java/com/github/plusvic/yara/YaraScanner.java
+++ b/src/main/java/com/github/plusvic/yara/YaraScanner.java
@@ -45,4 +45,14 @@ public interface YaraScanner extends AutoCloseable {
      * @param moduleArgs Module arguments (-x)
      */
     void scan(File file, Map<String, String> moduleArgs);
+  
+   /**
+     * Scan file
+     *
+     * @param file
+     * @param moduleArgs Module arguments (-x)
+     */
+    void scan(File file, Map<String, String> moduleArgs, YaraScanCallback cbk);
+  
+    void finalizeThread();
 }

--- a/src/main/java/com/github/plusvic/yara/embedded/YaraCompilerImpl.java
+++ b/src/main/java/com/github/plusvic/yara/embedded/YaraCompilerImpl.java
@@ -72,7 +72,11 @@ public class YaraCompilerImpl implements YaraCompiler {
         checkState(callback == null);
 
         callback = new Callback(new NativeCompilationCallback(library, cbk), "nativeOnError", 5);
-        library.compilerSetCallback(peer, callback.getAddress(), 0);
+        final long callBackAddress = callback.getAddress();
+        if(callBackAddress == 0) {
+          throw new IllegalStateException("Too many concurent callbacks, unable to create.");
+        }
+        library.compilerSetCallback(peer, callBackAddress, 0);
     }
 
     /**

--- a/src/main/java/com/github/plusvic/yara/embedded/YaraImpl.java
+++ b/src/main/java/com/github/plusvic/yara/embedded/YaraImpl.java
@@ -32,6 +32,11 @@ public class YaraImpl implements Yara {
 
         return new YaraCompilerImpl(this.library, compiler[0]);
     }
+  
+    @Override
+    public void finalizeThread() {
+        library.finalizeThread();
+    }
 
     @Override
     public void close() throws Exception {

--- a/src/main/java/com/github/plusvic/yara/embedded/YaraLibrary.java
+++ b/src/main/java/com/github/plusvic/yara/embedded/YaraLibrary.java
@@ -31,10 +31,17 @@ public class YaraLibrary implements Closeable {
     private final native int yr_finalize();
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         if (library != null) {
             yr_finalize();
             library = null;
+        }
+    }
+  
+    private final native void yr_finalize_thread();
+    public void finalizeThread() {
+        if (library != null) {
+            yr_finalize_thread();
         }
     }
 

--- a/src/main/java/com/github/plusvic/yara/external/YaraImpl.java
+++ b/src/main/java/com/github/plusvic/yara/external/YaraImpl.java
@@ -9,6 +9,10 @@ public class YaraImpl implements Yara {
     public YaraCompiler createCompiler() {
         return new YaraCompilerImpl();
     }
+  
+    @Override
+    public void finalizeThread() {
+    }
 
     @Override
     public void close() throws Exception {

--- a/src/main/java/com/github/plusvic/yara/external/YaraScannerImpl.java
+++ b/src/main/java/com/github/plusvic/yara/external/YaraScannerImpl.java
@@ -50,6 +50,10 @@ public class YaraScannerImpl implements YaraScanner {
 
     @Override
     public void scan(File file, Map<String, String> moduleArgs) {
+        scan(file, moduleArgs, this.callback);
+    }
+    @Override
+    public void scan(File file, Map<String, String> moduleArgs, YaraScanCallback yaraScanCallback) {
         checkArgument(file != null);
 
         if (!file.exists()) {
@@ -57,7 +61,7 @@ public class YaraScannerImpl implements YaraScanner {
         }
 
         try {
-            yara.match(file.toPath(), moduleArgs, callback);
+            yara.match(file.toPath(), moduleArgs, yaraScanCallback);
         } catch (Exception e) {
             throw new YaraException(e.getMessage());
         }
@@ -66,5 +70,8 @@ public class YaraScannerImpl implements YaraScanner {
 
     @Override
     public void close() throws Exception {
+    }
+    @Override
+    public void finalizeThread() {
     }
 }

--- a/src/test/java/com/github/plusvic/yara/embedded/YaraImplTest.java
+++ b/src/test/java/com/github/plusvic/yara/embedded/YaraImplTest.java
@@ -16,6 +16,13 @@ public class YaraImplTest {
         try (YaraImpl yara = new YaraImpl()) {
         }
     }
+  
+    @Test
+    public void testFinalizeThread() throws Exception {
+        try (YaraImpl yara = new YaraImpl()) {
+            yara.finalizeThread();
+        }
+    }
 
     @Test
     public void testCreateCompiler() throws Exception {


### PR DESCRIPTION
This patch enables YaraScanner to be reused across threads. In performance testing I found that reusing the YaraScanner can increase performance by up to 50%. This is most likely due to the overhead of creating the YARA_RULES object. The performance increase is only relevant to embedded mode.