### PR TITLE
fixed config arguments propagation for maven profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,6 @@
                         </goals>
                         <configuration>
                             <name>yara-wrapper</name>
-                            <configureArgs>
-                                <arg>LDFLAGS=${jni-with-crypto}</arg>
-                            </configureArgs>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
@p8a , after updating to yara 3.5 I got exactly the same error as before:

`Make based build did not generate: /home/m91snik/workspace/samples/yara-3.5.0/yara-java/target/native-build/target/lib/libyara-wrapper.so`

reason was that default
`
<configureArgs>
    <arg>LDFLAGS=${jni-with-crypto}</arg>
</configureArgs>
`
didn't allow maven plugin specific for profile use own configureArgs, i.e. 

`<arg>--libdir=${project.build.directory}/native-build/target/lib</arg>` was not applied for linux.

Removal of default configureArgs solved this issue.

Please approve PR and release new version as soon as you can, because I would like to use up-to-date yara 3.5 for my project, but cannot do it without this fix.

BR,
Nikolay