### PR TITLE
Adds the ability to scan a byte array to the YaraScanner API

### DIFF
--- a/src/main/java/com/github/plusvic/yara/YaraScanner.java
+++ b/src/main/java/com/github/plusvic/yara/YaraScanner.java
@@ -45,7 +45,7 @@ public interface YaraScanner extends AutoCloseable {
      * @param moduleArgs Module arguments (-x)
      */
     void scan(File file, Map<String, String> moduleArgs);
-  
+
    /**
      * Scan file
      *
@@ -53,6 +53,29 @@ public interface YaraScanner extends AutoCloseable {
      * @param moduleArgs Module arguments (-x)
      */
     void scan(File file, Map<String, String> moduleArgs, YaraScanCallback cbk);
-  
+
+    /**
+     * Scan memory
+     *
+     * @param buffer
+     */
+    void scan(byte[] buffer);
+
+    /**
+     * Scan memory
+     *
+     * @param buffer
+     * @param moduleArgs Module arguments (-x)
+     */
+    void scan(byte[] buffer, Map<String, String> moduleArgs);
+
+   /**
+     * Scan memory
+     *
+     * @param buffer
+     * @param moduleArgs Module arguments (-x)
+     */
+    void scan(byte[] buffer, Map<String, String> moduleArgs, YaraScanCallback cbk);
+
     void finalizeThread();
 }

--- a/src/main/java/com/github/plusvic/yara/embedded/YaraLibrary.java
+++ b/src/main/java/com/github/plusvic/yara/embedded/YaraLibrary.java
@@ -118,6 +118,23 @@ public class YaraLibrary implements Closeable {
         return yr_rules_scan_file(rules, filename, flags, callback, user_data, timeout);
     }
 
+   @JniMethod
+   private final native int yr_rules_scan_mem(
+            @JniArg(cast = "YR_RULES*") long rules,
+            byte[] buffer,
+            int length,
+            int flags,
+            @JniArg(cast = "YR_CALLBACK_FUNC") long callback,
+            @JniArg(cast = "void*") long user_data,
+            int timeout);
+   public int rulesScanMem(long rules, byte[] buffer, int flags, long callback, long user_data, int timeout) {
+        Preconditions.checkState(library != null);
+        return yr_rules_scan_mem(rules, buffer, buffer.length, flags, callback, user_data, timeout);
+   }
+   public int rulesScanMem(long rules, byte[] buffer, int buflen, int flags, long callback, long user_data, int timeout) {
+        Preconditions.checkState(library != null);
+        return yr_rules_scan_mem(rules, buffer, buflen, flags, callback, user_data, timeout);
+   }
 
     /*
         Mapping helpers

--- a/src/main/java/com/github/plusvic/yara/external/YaraScannerImpl.java
+++ b/src/main/java/com/github/plusvic/yara/external/YaraScannerImpl.java
@@ -69,8 +69,30 @@ public class YaraScannerImpl implements YaraScanner {
     }
 
     @Override
+    public void scan(byte[] buffer) {
+        scan(buffer, null);
+    }
+
+    @Override
+    public void scan(byte[] buffer, Map<String, String> moduleArgs) {
+        scan(buffer, moduleArgs, this.callback);
+    }
+
+    @Override
+    public void scan(byte[] buffer, Map<String, String> moduleArgs, YaraScanCallback yaraScanCallback) {
+        checkArgument(buffer != null);
+
+        try {
+            yara.match(buffer, moduleArgs, yaraScanCallback);
+        } catch (Exception e) {
+            throw new YaraException(e.getMessage());
+        }
+    }
+
+    @Override
     public void close() throws Exception {
     }
+
     @Override
     public void finalizeThread() {
     }


### PR DESCRIPTION
We embed yara in some of our process to scan memory buffers. Most of the functionality to do this using `libyara` is already built in, but is not exposed in `YaraScanner`. This patch sets adds a similar set of `scan` methods to the `YaraScanner` API that accept a `byte[]` instead of a `File`. 

Props to @mobileAgent for the initial time investment into this.