### PR TITLE
specify trusty distro for travis build, fix oraclejdk8 installation error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ jdk:
 os:
   - linux
 
+dist:
+  trusty
+
 before_install:
   - git clone https://github.com/virustotal/yara.git
   - cd yara


### PR DESCRIPTION
specify trusty distro for travis build to avoid oraclejdk8 installation issue described at https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365/2