### PR TITLE
Migrate to JUnit 5 and Mockito 4 + Java 8 Lambdas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hawtjni-version>1.14</hawtjni-version>
         <hawtjni-verbose>true</hawtjni-verbose>
-        <easymock-version>3.2</easymock-version>
+        <mockito-version>4.2.0</mockito-version>
         <jni-with-crypto>-lcrypto</jni-with-crypto>
     </properties>
 
@@ -30,11 +30,10 @@
             <artifactId>hawtjni-runtime</artifactId>
             <version>${hawtjni-version}</version>
         </dependency>
-
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -44,9 +43,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>${easymock-version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -142,6 +147,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/com/github/plusvic/yara/GenericIteratorTest.java
+++ b/src/test/java/com/github/plusvic/yara/GenericIteratorTest.java
@@ -1,11 +1,15 @@
 package com.github.plusvic.yara;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * User: pba
@@ -97,7 +101,7 @@ public class GenericIteratorTest {
         assertEquals(size, count);
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testNextFirst() {
         GenericIterator<String> it = new GenericIterator<String>() {
             private boolean used = false;
@@ -113,13 +117,13 @@ public class GenericIteratorTest {
         };
 
         assertNotNull(it.next());
-        assertNotNull(it.next());
+        Assertions.assertThrows(NoSuchElementException.class, it::next);
     }
 
     @Test
     public void testNextFirstMultiple() {
         GenericIterator<String> it = new GenericIterator<String>() {
-            private String values[] = new String[] { "one", "two"};
+            private final String[] values = new String[] { "one", "two"};
             private int pos = 0;
 
             @Override

--- a/src/test/java/com/github/plusvic/yara/UtilsTest.java
+++ b/src/test/java/com/github/plusvic/yara/UtilsTest.java
@@ -1,8 +1,9 @@
 package com.github.plusvic.yara;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 /**
  * User: pba

--- a/src/test/java/com/github/plusvic/yara/embedded/YaraCompilerImplTest.java
+++ b/src/test/java/com/github/plusvic/yara/embedded/YaraCompilerImplTest.java
@@ -1,11 +1,15 @@
 package com.github.plusvic.yara.embedded;
 
-import com.github.plusvic.yara.*;
+import com.github.plusvic.yara.TestUtils;
+import com.github.plusvic.yara.YaraCompilationCallback;
+import com.github.plusvic.yara.YaraCompiler;
+import com.github.plusvic.yara.YaraException;
+import com.github.plusvic.yara.YaraScanner;
 import net.jcip.annotations.NotThreadSafe;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -16,7 +20,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * User: pba
@@ -56,12 +63,13 @@ public class YaraCompilerImplTest {
 
     private YaraImpl yara;
 
-    @Before
+    @BeforeEach
     public void setup() {
+        System.out.println("assign yara");
         this.yara = new YaraImpl();
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         this.yara.close();
     }
@@ -87,12 +95,7 @@ public class YaraCompilerImplTest {
 
     @Test
     public void testAddRulesContentSucceeds() throws Exception {
-        YaraCompilationCallback callback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                fail();
-            }
-        };
+        YaraCompilationCallback callback = (errorLevel, fileName, lineNumber, message) -> fail();
 
         try (YaraCompiler compiler = yara.createCompiler()) {
             compiler.setCallback(callback);
@@ -103,13 +106,9 @@ public class YaraCompilerImplTest {
     @Test
     public void testAddRulesContentFails() throws Exception {
         final AtomicBoolean called = new AtomicBoolean();
-        YaraCompilationCallback callback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                called.set(true);
-                LOGGER.log(Level.INFO, String.format("Compilation failed in %s at %d: %s",
-                        fileName, lineNumber, message));
-            }
+        YaraCompilationCallback callback = (errorLevel, fileName, lineNumber, message) -> {
+            called.set(true);
+            LOGGER.log(Level.INFO, String.format("Compilation failed in %s at %d: %s", fileName, lineNumber, message));
         };
 
         try (YaraCompiler compiler = yara.createCompiler()) {
@@ -235,12 +234,7 @@ public class YaraCompilerImplTest {
 
     @Test
     public void testCreateScanner() throws Exception {
-        YaraCompilationCallback callback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                fail();
-            }
-        };
+        YaraCompilationCallback callback = (errorLevel, fileName, lineNumber, message) -> fail();
 
         try (YaraCompiler compiler = yara.createCompiler()) {
             compiler.setCallback(callback);
@@ -252,14 +246,10 @@ public class YaraCompilerImplTest {
         }
     }
 
-    @Ignore("yara asserts which stops execution")
+    @Test
+    @Disabled("yara asserts which stops execution")
     public void testAddRulesAfterScannerCreate() throws Exception {
-        YaraCompilationCallback callback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                fail();
-            }
-        };
+        YaraCompilationCallback callback = (errorLevel, fileName, lineNumber, message) -> fail();
 
         try (YaraCompiler compiler = yara.createCompiler()) {
             compiler.setCallback(callback);

--- a/src/test/java/com/github/plusvic/yara/embedded/YaraImplTest.java
+++ b/src/test/java/com/github/plusvic/yara/embedded/YaraImplTest.java
@@ -1,9 +1,9 @@
 package com.github.plusvic.yara.embedded;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.github.plusvic.yara.YaraCompiler;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * User: pba

--- a/src/test/java/com/github/plusvic/yara/embedded/YaraLibraryTest.java
+++ b/src/test/java/com/github/plusvic/yara/embedded/YaraLibraryTest.java
@@ -1,7 +1,7 @@
 package com.github.plusvic.yara.embedded;
 
 import net.jcip.annotations.NotThreadSafe;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/src/test/java/com/github/plusvic/yara/external/LineTokenizerTest.java
+++ b/src/test/java/com/github/plusvic/yara/external/LineTokenizerTest.java
@@ -1,10 +1,14 @@
 package com.github.plusvic.yara.external;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 /**
  * User: pba
@@ -12,9 +16,9 @@ import static org.junit.Assert.*;
  * Time: 6:15 PM
  */
 public class LineTokenizerTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNull() {
-        new LineTokenizer(null);
+        assertThrows(IllegalArgumentException.class, () ->new LineTokenizer(null));
     }
 
     @Test
@@ -300,7 +304,7 @@ public class LineTokenizerTest {
 
         assertEquals(new LineTokenizer.Token(LineTokenizer.TokenType.IDENTIFIER, "one"), tokens.next());
         assertEquals(new LineTokenizer.Token(LineTokenizer.TokenType.STRING, "this is a test"), tokens.next());
-        assertEquals(new LineTokenizer.Token(LineTokenizer.TokenType.STRING, "two"), tokens.next());;
+        assertEquals(new LineTokenizer.Token(LineTokenizer.TokenType.STRING, "two"), tokens.next());
 
         assertFalse(tokens.hasNext());
         assertEquals(LineTokenizer.EMPTY_TOKENS, tokenizer.next(LineTokenizer.TOKENS_ALL));

--- a/src/test/java/com/github/plusvic/yara/external/NativeExecutableTest.java
+++ b/src/test/java/com/github/plusvic/yara/external/NativeExecutableTest.java
@@ -1,10 +1,13 @@
 package com.github.plusvic.yara.external;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 /**
  * User: pba
@@ -12,14 +15,15 @@ import static org.junit.Assert.*;
  * Time: 8:55 AM
  */
 public class NativeExecutableTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNoName() {
-        new NativeExecutable("");
+        assertThrows(IllegalArgumentException.class, () -> new NativeExecutable(""));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullName() {
-        new NativeExecutable(null, NativeExecutableTest.class.getClassLoader());
+        assertThrows(IllegalArgumentException.class,
+            () -> new NativeExecutable(null, NativeExecutableTest.class.getClassLoader()));
     }
 
     @Test

--- a/src/test/java/com/github/plusvic/yara/external/YaraImplTest.java
+++ b/src/test/java/com/github/plusvic/yara/external/YaraImplTest.java
@@ -1,8 +1,8 @@
 package com.github.plusvic.yara.external;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * User: pba

--- a/src/test/java/com/github/plusvic/yara/external/YaraOutputProcessorTest.java
+++ b/src/test/java/com/github/plusvic/yara/external/YaraOutputProcessorTest.java
@@ -1,15 +1,20 @@
 package com.github.plusvic.yara.external;
 
 import com.github.plusvic.yara.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.easymock.EasyMock.createNiceMock;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+
 
 /**
  * User: pba
@@ -17,24 +22,19 @@ import static org.junit.Assert.*;
  * Time: 3:56 PM
  */
 public class YaraOutputProcessorTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNull() {
-        new YaraOutputProcessor(null);
+        assertThrows(IllegalArgumentException.class, () -> new YaraOutputProcessor(null));
     }
 
     @Test
     public void testCreate() {
-        new YaraOutputProcessor(createNiceMock(YaraScanCallback.class));
+        new YaraOutputProcessor(mock(YaraScanCallback.class));
     }
 
     @Test
     public void testStartComplete() {
-        YaraScanCallback callback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule rule) {
-                fail();
-            }
-        };
+        YaraScanCallback callback = rule -> fail();
 
         YaraOutputProcessor processor = new YaraOutputProcessor(callback);
         processor.onStart();
@@ -45,12 +45,7 @@ public class YaraOutputProcessorTest {
     public void testRuleNoMeta() {
         final AtomicReference<YaraRule> captureRule = new AtomicReference<>();
 
-        YaraScanCallback callback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule rule) {
-                captureRule.set(rule);
-            }
-        };
+        YaraScanCallback callback = captureRule::set;
 
         String value = "HelloWorld [] []";
 
@@ -69,12 +64,7 @@ public class YaraOutputProcessorTest {
     public void testRuleTags() {
         final AtomicReference<YaraRule> captureRule = new AtomicReference<>();
 
-        YaraScanCallback callback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule rule) {
-                captureRule.set(rule);
-            }
-        };
+        YaraScanCallback callback = captureRule::set;
 
         String value = "HelloWorld [One,Two,Three] []";
 
@@ -103,12 +93,7 @@ public class YaraOutputProcessorTest {
     public void testRuleMeta() {
         final AtomicReference<YaraRule> captureRule = new AtomicReference<>();
 
-        YaraScanCallback callback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule rule) {
-                captureRule.set(rule);
-            }
-        };
+        YaraScanCallback callback = captureRule::set;
 
         String value = "HelloWorld [] [name=\"InstallsDriver\",description=\"The file attempted to install a driver\"]";
 
@@ -140,12 +125,7 @@ public class YaraOutputProcessorTest {
     public void testRuleMetaAll() {
         final AtomicReference<YaraRule> captureRule = new AtomicReference<>();
 
-        YaraScanCallback callback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule rule) {
-                captureRule.set(rule);
-            }
-        };
+        YaraScanCallback callback = captureRule::set;
 
         String value = "HelloWorld [] [string=\"String\",number=1,boolean=true]";
 
@@ -181,12 +161,7 @@ public class YaraOutputProcessorTest {
     public void testRuleMetaUgly() {
         final AtomicReference<YaraRule> captureRule = new AtomicReference<>();
 
-        YaraScanCallback callback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule rule) {
-                captureRule.set(rule);
-            }
-        };
+        YaraScanCallback callback = captureRule::set;
 
         String value = "HelloWorld [One] [name=\"InstallsDriver\"," +
                 "description=\"The file attempted to install a driver\"," +
@@ -248,12 +223,7 @@ public class YaraOutputProcessorTest {
     public void testRuleMultiple() {
         final List<YaraRule> rules =new ArrayList<>();
 
-        YaraScanCallback callback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule rule) {
-                rules.add(rule);
-            }
-        };
+        YaraScanCallback callback = rules::add;
 
         String[] lines = new String[] {
                 "HelloWorld [] [name=\"InstallsDriver\",description=\"The file attempted to install a driver\"] test.bla",

--- a/src/test/java/com/github/plusvic/yara/external/YaraScannerImplTest.java
+++ b/src/test/java/com/github/plusvic/yara/external/YaraScannerImplTest.java
@@ -2,7 +2,7 @@ package com.github.plusvic.yara.external;
 
 import com.github.plusvic.yara.*;
 import net.jcip.annotations.NotThreadSafe;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -15,7 +15,13 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 
 /**
  * User: pba
@@ -51,9 +57,9 @@ public class YaraScannerImplTest {
             "}";
 
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNoRules() {
-        new YaraScannerImpl(null);
+        assertThrows(IllegalArgumentException.class, () -> new YaraScannerImpl(null));
     }
 
     @Test
@@ -61,26 +67,18 @@ public class YaraScannerImplTest {
         new YaraScannerImpl(Paths.get(System.getProperty("java.io.tmpdir")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWrongTimeout() {
-        new YaraScannerImpl(Paths.get(System.getProperty("java.io.tmpdir"))).setTimeout(-1);
+        YaraScannerImpl impl = new YaraScannerImpl(Paths.get(System.getProperty("java.io.tmpdir")));
+        assertThrows(IllegalArgumentException.class, () -> impl.setTimeout(-1));
     }
 
     @Test
     public void testSetCallback() throws Exception {
         //
-        YaraCompilationCallback compileCallback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                fail();
-            }
-        };
+        YaraCompilationCallback compileCallback = (errorLevel, fileName, lineNumber, message) -> fail();
 
-        YaraScanCallback scanCallback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule v) {
-            }
-        };
+        YaraScanCallback scanCallback = v -> {};
 
         // Create compiler and get scanner
         try (YaraCompiler compiler = new YaraCompilerImpl()) {
@@ -103,24 +101,16 @@ public class YaraScannerImplTest {
 
 
         //
-        YaraCompilationCallback compileCallback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                fail();
-            }
-        };
+        YaraCompilationCallback compileCallback = (errorLevel, fileName, lineNumber, message) -> fail();
 
         final AtomicBoolean match = new AtomicBoolean();
 
-        YaraScanCallback scanCallback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule v) {
-                assertEquals("HelloWorld", v.getIdentifier());
-                assertMetas(v.getMetadata());
-                assertStrings(v.getStrings());
+        YaraScanCallback scanCallback = v -> {
+            assertEquals("HelloWorld", v.getIdentifier());
+            assertMetas(v.getMetadata());
+            assertStrings(v.getStrings());
 
-                match.set(true);
-            }
+            match.set(true);
         };
 
         // Create compiler and get scanner
@@ -151,23 +141,14 @@ public class YaraScannerImplTest {
 
 
         //
-        YaraCompilationCallback compileCallback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                fail();
-            }
-        };
+        YaraCompilationCallback compileCallback = (errorLevel, fileName, lineNumber, message) -> fail();
 
         final AtomicInteger match = new AtomicInteger();
 
-        YaraScanCallback scanCallback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule v) {
-                assertMetas(v.getMetadata());
-                assertFalse(v.getStrings().hasNext());
-
-                match.incrementAndGet();
-            }
+        YaraScanCallback scanCallback = v -> {
+            assertMetas(v.getMetadata());
+            assertFalse(v.getStrings().hasNext());
+            match.incrementAndGet();
         };
 
         // Create compiler and get scanner
@@ -200,23 +181,14 @@ public class YaraScannerImplTest {
 
 
         //
-        YaraCompilationCallback compileCallback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                fail();
-            }
-        };
+        YaraCompilationCallback compileCallback = (errorLevel, fileName, lineNumber, message) -> fail();
 
         final AtomicInteger match = new AtomicInteger();
 
-        YaraScanCallback scanCallback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule v) {
-                assertMetas(v.getMetadata());
-                assertFalse(v.getStrings().hasNext());
-
-                match.incrementAndGet();
-            }
+        YaraScanCallback scanCallback = v -> {
+            assertMetas(v.getMetadata());
+            assertFalse(v.getStrings().hasNext());
+            match.incrementAndGet();
         };
 
         // Create compiler and get scanner
@@ -245,21 +217,11 @@ public class YaraScannerImplTest {
 
 
         //
-        YaraCompilationCallback compileCallback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                fail();
-            }
-        };
+        YaraCompilationCallback compileCallback = (errorLevel, fileName, lineNumber, message) -> fail();
 
         final AtomicBoolean match = new AtomicBoolean();
 
-        YaraScanCallback scanCallback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule v) {
-                match.set(true);
-            }
-        };
+        YaraScanCallback scanCallback = v -> match.set(true);
 
         // Create compiler and get scanner
         try (YaraCompiler compiler = new YaraCompilerImpl()) {
@@ -283,27 +245,16 @@ public class YaraScannerImplTest {
         File temp = File.createTempFile(UUID.randomUUID().toString(), ".tmp");
         Files.write(Paths.get(temp.getAbsolutePath()), "Hello world".getBytes(), StandardOpenOption.WRITE);
 
-        Map<String, String> moduleArgs = new HashMap();
+        Map<String, String> moduleArgs = new HashMap<>();
         moduleArgs.put("pe", temp.getAbsolutePath());
 
 
         //
-        YaraCompilationCallback compileCallback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                fail();
-            }
-        };
+        YaraCompilationCallback compileCallback = (errorLevel, fileName, lineNumber, message) -> fail();
 
         final AtomicBoolean match = new AtomicBoolean();
 
-        YaraScanCallback scanCallback = new YaraScanCallback() {
-            @Override
-            public void onMatch(YaraRule v) {
-
-                match.set(true);
-            }
-        };
+        YaraScanCallback scanCallback = v -> match.set(true);
 
 
         // Create compiler and get scanner

--- a/src/test/java/com/github/plusvic/yara/external/YaracExecutableTest.java
+++ b/src/test/java/com/github/plusvic/yara/external/YaracExecutableTest.java
@@ -2,15 +2,23 @@ package com.github.plusvic.yara.external;
 
 import com.github.plusvic.yara.TestUtils;
 import com.github.plusvic.yara.YaraCompilationCallback;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.easymock.EasyMock.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 
 /**
  * User: pba
@@ -23,26 +31,26 @@ public class YaracExecutableTest {
         new YaracExecutable();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNull() {
-        new YaracExecutable(null);
+        assertThrows(IllegalArgumentException.class, () -> new YaracExecutable(null));
     }
 
     @Test
     public void testCreateNativeExec() {
-        NativeExecutable exec = createNiceMock(NativeExecutable.class);
-        expect(exec.load()).andReturn(true).once();
-        replay(exec);
+        NativeExecutable exec = mock(NativeExecutable.class);
+        when(exec.load()).thenReturn(true);
 
         new YaracExecutable(exec);
 
-        verify(exec);
+        verify(exec, times(1)).load();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRuleNullNamespace() {
         YaracExecutable exec = new YaracExecutable();
-        assertEquals(exec, exec.addRule(null, Paths.get(System.getProperty("java.io.tmpdir"))));
+        Path tempdir = Paths.get(System.getProperty("java.io.tmpdir"));
+        assertThrows(IllegalArgumentException.class, () -> exec.addRule(null, tempdir));
     }
 
 
@@ -56,12 +64,7 @@ public class YaracExecutableTest {
     public void testExecuteNoArgs() throws Exception {
         final AtomicBoolean failure = new AtomicBoolean();
 
-        YaraCompilationCallback callback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                failure.set(true);
-            }
-        };
+        YaraCompilationCallback callback = (errorLevel, fileName, lineNumber, message) -> failure.set(true);
 
         Path output = new YaracExecutable().compile(callback);
         assertNotNull(output);
@@ -70,12 +73,7 @@ public class YaracExecutableTest {
 
     @Test
     public void testExecuteOK() throws Exception {
-        YaraCompilationCallback callback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                fail();
-            }
-        };
+        YaraCompilationCallback callback = (errorLevel, fileName, lineNumber, message) -> fail();
 
         Path output = new YaracExecutable()
                                 .addRule(TestUtils.getResource("rules/hello.yara"))
@@ -89,15 +87,12 @@ public class YaracExecutableTest {
     public void testExecuteError() throws Exception {
         final AtomicBoolean failure = new AtomicBoolean();
 
-        YaraCompilationCallback callback = new YaraCompilationCallback() {
-            @Override
-            public void onError(ErrorLevel errorLevel, String fileName, long lineNumber, String message) {
-                assertEquals(ErrorLevel.ERROR, errorLevel);
-                assertTrue(fileName.endsWith("error.yara"));
-                assertEquals(13, lineNumber);
-                assertTrue(message.endsWith("$b\""));
-                failure.set(true);
-            }
+        YaraCompilationCallback callback = (errorLevel, fileName, lineNumber, message) -> {
+            assertEquals(YaraCompilationCallback.ErrorLevel.ERROR, errorLevel);
+            assertTrue(fileName.endsWith("error.yara"));
+            assertEquals(13, lineNumber);
+            assertTrue(message.endsWith("$b\""));
+            failure.set(true);
         };
 
         Path output = new YaracExecutable()


### PR DESCRIPTION
Refactor the test suite to be more state of the art.

* I migrated it to Mockito 4 since Easymock struggles on JDK 17.
* Migrate the project to JUnit 5 (not entirely beatifully but more like everything needed to get it running and change as less code as possible - junit 5 actually has some more beautiful tools as well like extensions etc.)
* Migrate anonymous inner classes to lambdas.